### PR TITLE
Update credentials-binding plugin

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -28,7 +28,7 @@ cloudbees-bitbucket-branch-source:2.2.10
 cloudbees-folder:6.3
 command-launcher:1.2
 configuration-as-code:0.3-alpha
-credentials-binding:1.15
+credentials-binding:1.16
 credentials:2.1.16
 display-url-api:2.2.0
 docker-commons:1.11


### PR DESCRIPTION
The git credentials binding doesn't work well on credentials-binding 1.15. As a results, git API usages sent anonymously. Anonymous git API has limit of 60 requests. 
Before upgrade:
`GitHub API Usage: Current quota has 47 remaining (0 under budget). Next quota of 60 in 49 min`
After upgrade:
`Connecting to https://api.github.com using yahavi/****** (API Token for acccessing https://github.com git service inside pipelines)`