### PR TITLE
Gitlab plugin name incorrect

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -42,7 +42,7 @@ gitea:1.0.8
 github-api:1.92
 github-branch-source:2.3.6
 github:1.29.1
-gitlab:1.5.5
+gitlab-plugin:1.5.5
 handlebars:1.1.1
 handy-uri-templates-2-api:2.1.6-1.0
 htmlpublisher:1.16


### PR DESCRIPTION
When I'm running `docker build` I get:
`curl: (22) The requested URL returned error: 404 Not Found
07:35:25 Failure (22) Retrying in 1 seconds...`
After investigation I found out that `gitlab` need to be `gitlab-plugin`