### PR TITLE
reintroduce kubernetes-credentials-provider

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -58,6 +58,7 @@ junit:1.26.1
 jx-resources:1.0.27
 kubernetes-credentials:0.4.0
 kubernetes:1.14.3
+kubernetes-credentials-provider:0.11
 mailer:1.23
 matrix-project:1.13
 mercurial:2.4


### PR DESCRIPTION
in effect revert 45ce66ae8e581d5adcd09507749bee28173add90 which was a
bad merge and removed the plugin rather than using the version that was
updated.

@garethjevans 